### PR TITLE
Pc fix unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,13 @@
             <version>0.8.5</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.22.0</version>
+            <scope>test</scope>
+        </dependency>
+        
     </dependencies>
     <!-- (24) <repositories/> -->
     <!-- (25) <pluginRepositories/> -->

--- a/src/test/java/hello/HomePageTest.java
+++ b/src/test/java/hello/HomePageTest.java
@@ -15,14 +15,23 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.xpath;
 
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
-@AutoConfigureMockMvc
+@WebMvcTest(WebController.class)
 public class HomePageTest {
 
     @Autowired
     private MockMvc mvc;
+
+    @MockBean
+    private AuthControllerAdvice aca;
+
+    @MockBean
+    private ClientRegistrationRepository crr;
 
     @Test
     public void getHomePage_ContentType() throws Exception {
@@ -30,7 +39,6 @@ public class HomePageTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType("text/html;charset=UTF-8"));
     }
-
 
     @Test
     public void getHomePage_BootstrapLoaded() throws Exception {
@@ -45,7 +53,6 @@ public class HomePageTest {
         }
     }
 
-
     @Test
     public void getHomePage_hasCorrectTitle() throws Exception {
         mvc.perform(MockMvcRequestBuilders.get("/").accept(MediaType.TEXT_HTML))
@@ -53,7 +60,6 @@ public class HomePageTest {
                 .andExpect(xpath("//title").exists())
                 .andExpect(xpath("//title").string("CS56 Spring Boot Practice App"));
     }
-
 
     @Test
     public void getHomePage_hasCorrectBrand() throws Exception {


### PR DESCRIPTION
In this PR, we do three things:

1.  We update the version of Mockito in the `pom.xml` per this article: 
   
   <https://dev.to/scottshipp/how-to-fix-a-mockito-cannot-mock-this-class-exception-in-a-spring-boot-app-457e>

2. We use mock beans for two beans that were causing unit tests to fail when oauth credentials were not defined.

3. We use `@WebMvcTest(WebController.class)` which bypasses OAuth stuff.
