### PR TITLE
Pc fix earthquake test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ localhost.json
 .classpath
 .project
 .settings
+.vscode/
 
 # For Maven
 target

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,15 @@
             <version>2.22.0</version>
             <scope>test</scope>
         </dependency>
-        
+
+        <!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-test -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
     </dependencies>
     <!-- (24) <repositories/> -->
     <!-- (25) <pluginRepositories/> -->

--- a/src/main/resources/templates/earthquakes/search.html
+++ b/src/main/resources/templates/earthquakes/search.html
@@ -16,15 +16,15 @@
             <table>
                 <tr class="form-group">
                     <th><label for="distance" class="col-form-label">Distance (km)</label></th>
-                    <td><input type="number" th:field="*{distance}" class="form-control" id="distance"></td>
+                    <td><input type="number" th:field="*{distance}" class="form-control" id="distance" /></td>
                 </tr>
                 <tr class="form-group">
                     <th><label for="minmag" class="col-form-label">Minimum Magnitude</label></th>
-                    <td><input type="number" th:field="*{minmag}" class="form-control" id="minmag"></td>
+                    <td><input type="number" th:field="*{minmag}" class="form-control" id="minmag" /></td>
                 </tr>
             </table>
 
-            <input type="submit" class="btn btn-primary" value="Search">
+            <input type="submit" class="btn btn-primary" value="Search" /> 
         </form>
 
         <div th:replace="bootstrap/bootstrap_footer.html"></div>

--- a/src/test/java/hello/EarthquakeSearchTest.java
+++ b/src/test/java/hello/EarthquakeSearchTest.java
@@ -1,0 +1,59 @@
+package hello;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.xpath;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.junit.Before;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(WebController.class)
+public class EarthquakeSearchTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private AuthControllerAdvice aca;
+
+    @MockBean
+    private ClientRegistrationRepository crr;
+
+    private OAuth2User principal;
+
+    /**
+     * Set up an OAuth mock user so that we can unit test protected endpoints
+     */
+    @Before
+    public void setUpUser() {
+        principal = OAuthUtils.createOAuth2User("Chris Gaucho", "cgaucho@example.com");
+    }
+
+    @Test
+    @WithMockUser
+    public void getEarthquakeSearch() throws Exception {
+        mvc.perform(MockMvcRequestBuilders.get("/earthquakes/search")
+            .with(authentication(OAuthUtils.getOauthAuthenticationFor(principal)))
+            .accept(MediaType.TEXT_HTML))
+            .andExpect(status().isOk())
+            .andExpect(xpath("//title").exists())
+            .andExpect(xpath("//title").string("Earthquake Search"));
+}
+}

--- a/src/test/java/hello/OAuthUtils.java
+++ b/src/test/java/hello/OAuthUtils.java
@@ -1,0 +1,52 @@
+package hello;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
+
+
+/**
+ * Utility methods for testing OAuth protected endpoints.
+ * <a href="https://github.com/mark-hoogenboom/spring-boot-oauth-testing">
+ * https://github.com/mark-hoogenboom/spring-boot-oauth-testing
+ * </a>
+ */
+
+public class OAuthUtils {
+
+    public static OAuth2User createOAuth2User(String name, String email) {
+
+        Map<String, Object> authorityAttributes = new HashMap<>();
+        authorityAttributes.put("key", "value");
+
+        GrantedAuthority authority = new OAuth2UserAuthority(authorityAttributes);
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("sub", "1234567890");
+        attributes.put("name", name);
+        attributes.put("email", email);
+
+        Set<GrantedAuthority> authorities = new HashSet<GrantedAuthority>();
+        authorities.add(authority);
+
+        return new DefaultOAuth2User(authorities, attributes, "sub");
+    }
+
+    public static Authentication getOauthAuthenticationFor(OAuth2User principal) {
+
+        Collection<? extends GrantedAuthority> authorities = principal.getAuthorities();
+
+        String authorizedClientRegistrationId = "my-oauth-client";
+
+        return new OAuth2AuthenticationToken(principal, authorities, authorizedClientRegistrationId);
+    }
+}


### PR DESCRIPTION
This PR addresses the 302 errors that students were getting with the step where they added a test for the Earthquake Search form.

That endpoint is protected behind OAuth authentication, and as a result, it is necessary to mock and stub the OAuth mechanism.

We used techniques from this article:
<https://medium.com/@mark.hoogenboom/testing-a-spring-boot-application-secured-by-oauth-e40d1e9a6f60>